### PR TITLE
Link Robinson Business Ventures website

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -490,6 +490,8 @@ button { font: inherit; }
 .venture-note-body p { max-width: 66ch; color: var(--prose); font-size: 15px; line-height: 1.7; }
 .venture-note-values { display: flex; flex-wrap: wrap; gap: 7px; margin-top: 18px; list-style: none; }
 .venture-note-values li { padding: 6px 9px; border: 1px solid var(--line); color: var(--muted); font-family: var(--font-mono); font-size: 9px; }
+.venture-note-link { min-height: 44px; display: inline-flex; align-items: center; gap: 8px; margin-top: 14px; border-bottom: 1px solid transparent; font-size: 14px; font-weight: 600; }
+.venture-note-link:hover { color: var(--accent); border-color: var(--accent); }
 
 .lab-block {
     display: grid;

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-    <link href="css/styles.css?v=20260716-3" rel="stylesheet">
+    <link href="css/styles.css?v=20260716-4" rel="stylesheet">
 
     <script type="application/ld+json">
     {
@@ -54,7 +54,7 @@
         "email": "mailto:snrobinson94@gmail.com",
         "image": "https://www.snrobinson.com/images/stephen-robinson-headshot.jpg",
         "worksFor": { "@type": "Organization", "name": "NBCUniversal" },
-        "affiliation": { "@type": "Organization", "name": "Robinson Business Ventures LLC" },
+        "affiliation": { "@type": "Organization", "name": "Robinson Business Ventures LLC", "url": "https://www.robinsonbizventures.com/" },
         "alumniOf": [
             { "@type": "CollegeOrUniversity", "name": "Pennsylvania State University" },
             { "@type": "CollegeOrUniversity", "name": "University of South Florida" }
@@ -64,7 +64,8 @@
         "sameAs": [
             "https://www.linkedin.com/in/stephen-robinson-877ab46b/",
             "https://github.com/snrobinson",
-            "https://www.robinson-consulting-group.com"
+            "https://www.robinson-consulting-group.com",
+            "https://www.robinsonbizventures.com/"
         ]
     }
     </script>
@@ -77,7 +78,7 @@
         "applicationCategory": "GameApplication",
         "url": "https://apps.apple.com/us/app/snake-rush-arcade/id6761447721",
         "author": { "@type": "Person", "name": "Stephen Robinson" },
-        "publisher": { "@type": "Organization", "name": "Robinson Business Ventures LLC" }
+        "publisher": { "@type": "Organization", "name": "Robinson Business Ventures LLC", "url": "https://www.robinsonbizventures.com/" }
     }
     </script>
 </head>
@@ -229,6 +230,7 @@
                             <li>Integrity</li>
                             <li>Long-term family ownership</li>
                         </ul>
+                        <a href="https://www.robinsonbizventures.com/" target="_blank" rel="noopener" class="venture-note-link" aria-label="Visit Robinson Business Ventures in a new tab">Visit company site <span aria-hidden="true">↗</span></a>
                     </div>
                 </article>
 

--- a/jarvis/index.html
+++ b/jarvis/index.html
@@ -34,7 +34,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-    <link href="../css/styles.css?v=20260716-3" rel="stylesheet">
+    <link href="../css/styles.css?v=20260716-4" rel="stylesheet">
     <link href="jarvis.css" rel="stylesheet">
 </head>
 


### PR DESCRIPTION
## What changed

- Adds a visible “Visit company site” link to the Robinson Business Ventures feature.
- Associates `robinsonbizventures.com` with RBV in the portfolio's structured metadata.
- Identifies Robinson Business Ventures' website in the Snake Rush Arcade publisher metadata.
- Refreshes the shared stylesheet URL so the new link styling loads immediately.

## Why

The portfolio introduced Robinson Business Ventures and its connection to Snake Rush Arcade, but did not provide visitors or search engines with the company's website.

## Impact

Visitors can now continue directly to the RBV website, and the company relationship is clearer to search engines.

## Validation

- Confirmed `https://www.robinsonbizventures.com/` responds successfully.
- Validated JavaScript syntax, structured data, and whitespace.
