### PR TITLE
Fix mobile navigation and system theme

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,6 +1,7 @@
 /* Stephen Robinson — technical/editorial portfolio */
 
 :root {
+    color-scheme: dark;
     --bg: #0c0c0d;
     --bg-elevated: #121214;
     --bg-soft: rgba(255, 255, 255, 0.035);
@@ -24,6 +25,7 @@
 }
 
 [data-theme="light"] {
+    color-scheme: light;
     --bg: #f4f1ea;
     --bg-elevated: #faf8f3;
     --bg-soft: rgba(0, 0, 0, 0.035);
@@ -185,6 +187,8 @@ button { font: inherit; }
     background: transparent;
     border: 1px solid transparent;
     cursor: pointer;
+    touch-action: manipulation;
+    -webkit-tap-highlight-color: transparent;
     transition: color var(--transition), border-color var(--transition), background-color var(--transition);
 }
 
@@ -615,10 +619,11 @@ button { font: inherit; }
 
     .nav-links {
         display: none;
-        position: absolute;
+        position: fixed;
         top: 66px;
         left: 0;
         right: 0;
+        z-index: 110;
         flex-direction: column;
         align-items: stretch;
         gap: 0;
@@ -626,19 +631,22 @@ button { font: inherit; }
         background: var(--bg);
         border-bottom: 1px solid var(--line);
         box-shadow: 0 16px 30px rgba(0, 0, 0, 0.18);
+        max-height: calc(100dvh - 66px);
+        overflow-y: auto;
     }
 
     .nav-links.open { display: flex; }
-    .nav-links a { min-height: 48px; font-size: 13px; }
+    .nav-links a { min-height: 52px; font-size: 13px; }
     .nav-links a::after { bottom: 5px; }
     .nav-toggle { display: inline-flex; }
+    body.nav-open { overflow: hidden; }
 
-    .hero { padding: 34px 0 50px; }
-    .hero-grid { position: relative; display: block; }
-    .hero-text { padding-top: 144px; }
-    .hero-portrait { position: absolute; top: 0; left: 0; width: 118px; }
-    .hero-portrait-frame::before { transform: translate(8px, 8px); }
-    .hero-portrait figcaption { display: none; }
+    .hero { padding: 30px 0 50px; }
+    .hero-grid { display: flex; flex-direction: column; align-items: stretch; gap: 30px; }
+    .hero-text { padding-top: 0; }
+    .hero-portrait { order: -1; width: min(100%, 320px); margin-inline: auto; }
+    .hero-portrait-frame::before { transform: translate(10px, 10px); }
+    .hero-portrait figcaption { display: block; margin-top: 18px; text-align: center; font-size: 9px; letter-spacing: 0.025em; }
     .kicker { margin-bottom: 16px; font-size: 10px; }
     .hero-h1 { margin-bottom: 18px; font-size: clamp(43px, 13vw, 58px); }
     .lead { font-size: 16px; }

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="dark light">
+    <meta name="theme-color" content="#0c0c0d">
     <title>Stephen Robinson — Technical Program Leader &amp; Applied AI Builder</title>
     <meta name="description" content="Stephen Robinson leads high-stakes enterprise technology programs and builds practical AI systems. Explore selected work, measurable outcomes, and consulting capabilities.">
     <meta name="author" content="Stephen Robinson">
@@ -11,12 +13,10 @@
 
     <script>
         (function () {
-            var theme = 'dark';
-            try {
-                var saved = localStorage.getItem('theme');
-                theme = saved || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
-            } catch (e) { }
+            var theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            try { theme = sessionStorage.getItem('themeOverride') || theme; } catch (e) { }
             document.documentElement.setAttribute('data-theme', theme);
+            document.querySelector('meta[name="theme-color"]').setAttribute('content', theme === 'light' ? '#f4f1ea' : '#0c0c0d');
         })();
     </script>
 
@@ -36,12 +36,10 @@
     <link rel="icon" href="favicon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="images/apple-touch-icon.png">
     <link rel="manifest" href="site.webmanifest">
-    <meta name="theme-color" content="#0c0c0d">
-
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-    <link href="css/styles.css?v=20260717-8" rel="stylesheet">
+    <link href="css/styles.css?v=20260717-9" rel="stylesheet">
 
     <script type="application/ld+json">
     {
@@ -97,11 +95,11 @@
                 <a href="#contact">contact</a>
             </nav>
             <div class="header-actions">
-                <button class="theme-toggle" id="themeToggle" aria-label="Switch to light theme" title="Switch theme">
+                <button class="theme-toggle" id="themeToggle" type="button" aria-label="Switch to light theme" title="Switch theme">
                     <svg class="icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"></path></svg>
                 </button>
-                <button class="nav-toggle" id="navToggle" aria-label="Open navigation" aria-expanded="false" aria-controls="navLinks">menu</button>
+                <button class="nav-toggle" id="navToggle" type="button" aria-label="Open navigation" aria-expanded="false" aria-controls="navLinks">menu</button>
             </div>
         </div>
     </header>
@@ -447,7 +445,7 @@
         </div>
     </footer>
 
-    <script src="scripts/scripts.js"></script>
+    <script src="scripts/scripts.js?v=20260717-2"></script>
 </body>
 
 </html>

--- a/jarvis/index.html
+++ b/jarvis/index.html
@@ -4,18 +4,18 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="color-scheme" content="dark light">
+    <meta name="theme-color" content="#0c0c0d">
     <title>JARVIS — Executive AI Agent | Stephen Robinson</title>
     <meta name="description" content="Case study: how Stephen Robinson is designing JARVIS, a context-aware executive AI agent that understands, anticipates, coordinates, and learns.">
     <link rel="canonical" href="https://www.snrobinson.com/jarvis/">
 
     <script>
         (function () {
-            var theme = 'dark';
-            try {
-                var saved = localStorage.getItem('theme');
-                theme = saved || (window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark');
-            } catch (e) { }
+            var theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+            try { theme = sessionStorage.getItem('themeOverride') || theme; } catch (e) { }
             document.documentElement.setAttribute('data-theme', theme);
+            document.querySelector('meta[name="theme-color"]').setAttribute('content', theme === 'light' ? '#f4f1ea' : '#0c0c0d');
         })();
     </script>
 
@@ -29,12 +29,10 @@
 
     <link rel="icon" href="../favicon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="../images/apple-touch-icon.png">
-    <meta name="theme-color" content="#0c0c0d">
-
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-    <link href="../css/styles.css?v=20260717-8" rel="stylesheet">
+    <link href="../css/styles.css?v=20260717-9" rel="stylesheet">
     <link href="jarvis.css?v=20260716-2" rel="stylesheet">
 </head>
 
@@ -52,11 +50,11 @@
                 <a href="../#contact">contact</a>
             </nav>
             <div class="header-actions">
-                <button class="theme-toggle" id="themeToggle" aria-label="Switch to light theme" title="Switch theme">
+                <button class="theme-toggle" id="themeToggle" type="button" aria-label="Switch to light theme" title="Switch theme">
                     <svg class="icon-moon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
                     <svg class="icon-sun" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"></circle><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"></path></svg>
                 </button>
-                <button class="nav-toggle" id="navToggle" aria-label="Open navigation" aria-expanded="false" aria-controls="navLinks">menu</button>
+                <button class="nav-toggle" id="navToggle" type="button" aria-label="Open navigation" aria-expanded="false" aria-controls="navLinks">menu</button>
             </div>
         </div>
     </header>
@@ -214,7 +212,7 @@
         <div class="wrap footer-inner"><span>© 2026 Stephen Robinson</span><a href="#top">Back to top ↑</a></div>
     </footer>
 
-    <script src="../scripts/scripts.js"></script>
+    <script src="../scripts/scripts.js?v=20260717-2"></script>
 </body>
 
 </html>

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -3,8 +3,12 @@
     var toggle = document.getElementById('themeToggle');
     var themeColor = document.querySelector('meta[name="theme-color"]');
     if (!toggle) return;
+    var systemTheme = window.matchMedia('(prefers-color-scheme: dark)');
+    var override = null;
+    try { override = sessionStorage.getItem('themeOverride'); } catch (e) { }
 
-    var updateThemeControl = function () {
+    var applyTheme = function (theme) {
+        document.documentElement.setAttribute('data-theme', theme);
         var isLight = document.documentElement.getAttribute('data-theme') === 'light';
         var label = isLight ? 'Switch to dark theme' : 'Switch to light theme';
         toggle.setAttribute('aria-label', label);
@@ -14,13 +18,19 @@
 
     toggle.addEventListener('click', function () {
         var isLight = document.documentElement.getAttribute('data-theme') === 'light';
-        var next = isLight ? 'dark' : 'light';
-        document.documentElement.setAttribute('data-theme', next);
-        try { localStorage.setItem('theme', next); } catch (e) { }
-        updateThemeControl();
+        override = isLight ? 'dark' : 'light';
+        try { sessionStorage.setItem('themeOverride', override); } catch (e) { }
+        applyTheme(override);
     });
 
-    updateThemeControl();
+    var syncWithSystem = function (event) {
+        if (!override) applyTheme(event.matches ? 'dark' : 'light');
+    };
+
+    if (systemTheme.addEventListener) systemTheme.addEventListener('change', syncWithSystem);
+    else if (systemTheme.addListener) systemTheme.addListener(syncWithSystem);
+
+    applyTheme(override || (systemTheme.matches ? 'dark' : 'light'));
 })();
 
 // Sticky-header divider.
@@ -44,6 +54,7 @@
 
     var setOpen = function (open, returnFocus) {
         navLinks.classList.toggle('open', open);
+        document.body.classList.toggle('nav-open', open);
         navToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
         navToggle.setAttribute('aria-label', open ? 'Close navigation' : 'Open navigation');
         navToggle.textContent = open ? 'close' : 'menu';


### PR DESCRIPTION
## Summary

- restore reliable mobile menu open, close, and destination behavior
- prevent stale cached JavaScript from leaving the menu unresponsive
- redesign the mobile hero around a centered, nearly full-width portrait
- initialize light or dark mode from the device preference and respond to system changes
- retain the manual theme toggle as a temporary per-session override

## Root cause

The shared interaction script did not have a cache-busting version, so mobile browsers could continue using an older copy even after the menu logic changed. The portrait was also intentionally positioned as a small absolute element at the mobile breakpoint, which reduced its visual presence.

## Validation

- opened and closed the mobile menu and selected a destination
- reviewed the mobile hero at a phone-sized viewport
- checked light and dark presentations
- verified JavaScript syntax, structured data, and clean diff formatting
