### PR TITLE
Reset portfolio to top on refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,19 @@
 
     <script>
         (function () {
+            var navigation = performance.getEntriesByType && performance.getEntriesByType('navigation')[0];
+            var reloaded = navigation
+                ? navigation.type === 'reload'
+                : performance.navigation && performance.navigation.type === 1;
+
+            if (reloaded) {
+                if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
+                if (window.location.hash) {
+                    history.replaceState(null, '', window.location.pathname + window.location.search);
+                }
+                window.scrollTo(0, 0);
+            }
+
             var theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
             try { theme = sessionStorage.getItem('themeOverride') || theme; } catch (e) { }
             document.documentElement.setAttribute('data-theme', theme);
@@ -474,7 +487,7 @@
         </div>
     </footer>
 
-    <script src="scripts/scripts.js?v=20260717-3"></script>
+    <script src="scripts/scripts.js?v=20260717-4"></script>
 </body>
 
 </html>

--- a/jarvis/index.html
+++ b/jarvis/index.html
@@ -12,6 +12,19 @@
 
     <script>
         (function () {
+            var navigation = performance.getEntriesByType && performance.getEntriesByType('navigation')[0];
+            var reloaded = navigation
+                ? navigation.type === 'reload'
+                : performance.navigation && performance.navigation.type === 1;
+
+            if (reloaded) {
+                if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
+                if (window.location.hash) {
+                    history.replaceState(null, '', window.location.pathname + window.location.search);
+                }
+                window.scrollTo(0, 0);
+            }
+
             var theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
             try { theme = sessionStorage.getItem('themeOverride') || theme; } catch (e) { }
             document.documentElement.setAttribute('data-theme', theme);
@@ -217,7 +230,7 @@
         <div class="wrap footer-inner"><span>© 2026 Stephen Robinson</span><a href="#top">Back to top ↑</a></div>
     </footer>
 
-    <script src="../scripts/scripts.js?v=20260717-3"></script>
+    <script src="../scripts/scripts.js?v=20260717-4"></script>
 </body>
 
 </html>

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1,3 +1,36 @@
+// Reloads always begin at the top without overriding intentional hash navigation.
+(function () {
+    var navigation = null;
+    if (window.performance && performance.getEntriesByType) {
+        navigation = performance.getEntriesByType('navigation')[0] || null;
+    }
+
+    var reloaded = navigation
+        ? navigation.type === 'reload'
+        : !!(window.performance && performance.navigation && performance.navigation.type === 1);
+
+    if (!reloaded) return;
+
+    if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
+    if (window.location.hash) {
+        history.replaceState(null, '', window.location.pathname + window.location.search);
+    }
+
+    var reset = function () {
+        window.scrollTo(0, 0);
+    };
+
+    reset();
+    window.addEventListener('load', reset, { once: true });
+    window.addEventListener('pageshow', reset, { once: true });
+    requestAnimationFrame(function () {
+        requestAnimationFrame(reset);
+    });
+    [100, 250, 500, 1000].forEach(function (delay) {
+        window.setTimeout(reset, delay);
+    });
+})();
+
 // Theme preference and accessible toggle state.
 (function () {
     var toggle = document.getElementById('themeToggle');


### PR DESCRIPTION
## Summary

- reset the portfolio to the top whenever the browser refreshes the page
- apply the same behavior to the JARVIS case study
- preserve normal section-link navigation when the page is not being refreshed

## Validation

- verified refresh behavior from anchored sections on the mobile portfolio view
- verified refresh behavior from anchored sections on the mobile JARVIS view
- confirmed normal `#contact` and `#outcomes` navigation still works
- passed JavaScript syntax and diff consistency checks
