### PR TITLE
Display complete NBCUniversal wordmark

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -537,10 +537,12 @@ button { font: inherit; }
 .xp:first-child { padding-top: 0; border-top: none; }
 .xp-meta { display: flex; flex-direction: column; gap: 5px; }
 .xp-brand { display: grid; grid-template-columns: 50px minmax(0, 1fr); gap: 12px; align-items: center; margin-bottom: 4px; }
+.xp-brand--nbcu { grid-template-columns: minmax(0, 200px); }
 .xp-company-copy { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
 .xp-logo { width: 50px; height: 50px; display: grid; place-items: center; overflow: hidden; border: 1px solid var(--line); border-radius: var(--radius); background: #0a0a0c; }
 .xp-logo img { width: 38px; height: 38px; max-width: none; object-fit: contain; }
-.xp-logo--nbcu img { width: auto; height: 30px; justify-self: start; }
+.xp-logo--nbcu { width: 200px; padding: 10px 12px; }
+.xp-logo--nbcu img { width: 100%; height: auto; max-width: 100%; }
 .xp-logo--onphase img { width: 44px; height: 44px; transform: scale(1.2); }
 .xp-logo--fairfax img { width: 40px; height: 40px; }
 .xp-co { font-family: var(--font-display); font-size: 16px; font-weight: 500; line-height: 1.4; }

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-    <link href="css/styles.css?v=20260717-11" rel="stylesheet">
+    <link href="css/styles.css?v=20260717-12" rel="stylesheet">
 
     <script type="application/ld+json">
     {
@@ -310,9 +310,9 @@
                     <ol class="xp-list">
                         <li class="xp">
                             <div class="xp-meta">
-                                <div class="xp-brand">
+                                <div class="xp-brand xp-brand--nbcu">
                                     <span class="xp-logo xp-logo--nbcu" aria-hidden="true"><img src="images/companies/nbcuniversal.png" alt=""></span>
-                                    <span class="xp-co">NBCUniversal</span>
+                                    <span class="sr-only">NBCUniversal</span>
                                 </div>
                                 <span class="xp-date">2022 — Present</span>
                             </div>
@@ -329,9 +329,9 @@
 
                         <li class="xp">
                             <div class="xp-meta">
-                                <div class="xp-brand">
+                                <div class="xp-brand xp-brand--nbcu">
                                     <span class="xp-logo xp-logo--nbcu" aria-hidden="true"><img src="images/companies/nbcuniversal.png" alt=""></span>
-                                    <span class="xp-co">NBCUniversal</span>
+                                    <span class="sr-only">NBCUniversal</span>
                                 </div>
                                 <span class="xp-date">2019 — 2022</span>
                             </div>

--- a/jarvis/index.html
+++ b/jarvis/index.html
@@ -45,7 +45,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-    <link href="../css/styles.css?v=20260717-11" rel="stylesheet">
+    <link href="../css/styles.css?v=20260717-12" rel="stylesheet">
     <link href="jarvis.css?v=20260716-2" rel="stylesheet">
 </head>
 


### PR DESCRIPTION
## Summary

- display the complete, official NBCUniversal horizontal wordmark in the Experience section
- replace the cropped peacock-only presentation and duplicate typed company name
- retain the existing company logo treatment for OnPhase and Fairfax Software
- update the style cache marker so the corrected logo reaches browsers immediately

## Validation

- compared the local source file with NBCUniversal's current official corporate logo asset
- verified the complete wordmark on mobile in light mode
- verified the complete wordmark on mobile in dark mode
- passed consistency and whitespace checks
