### PR TITLE
Align credential institution column

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -565,10 +565,10 @@ button { font: inherit; }
 
 /* Credentials */
 .cred-list { list-style: none; }
-.cred { min-height: 58px; display: grid; grid-template-columns: 1.4fr 1fr auto; gap: 22px; align-items: center; padding: 14px 0; border-top: 1px solid var(--line); }
+.cred { min-height: 58px; display: grid; grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) 190px; gap: 22px; align-items: center; padding: 14px 0; border-top: 1px solid var(--line); }
 .cred:first-child { border-top: none; padding-top: 0; }
 .cred-name { font-family: var(--font-display); font-size: 15px; font-weight: 500; }
-.cred-org { color: var(--muted); font-size: 13px; }
+.cred-org { color: var(--muted); font-size: 13px; text-align: left; }
 .cred-status { color: var(--accent); font-family: var(--font-mono); font-size: 10px; text-align: right; }
 .cred-prior { opacity: 0.86; }
 .cred-prior .cred-status { color: var(--faint); }

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-    <link href="css/styles.css?v=20260717-12" rel="stylesheet">
+    <link href="css/styles.css?v=20260717-13" rel="stylesheet">
 
     <script type="application/ld+json">
     {

--- a/jarvis/index.html
+++ b/jarvis/index.html
@@ -45,7 +45,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-    <link href="../css/styles.css?v=20260717-12" rel="stylesheet">
+    <link href="../css/styles.css?v=20260717-13" rel="stylesheet">
     <link href="jarvis.css?v=20260716-2" rel="stylesheet">
 </head>
 


### PR DESCRIPTION
## Summary

- align every institution in the Credentials section to a shared column start
- reserve a consistent right-side width for credential status text
- retain the responsive single-column credentials layout on mobile
- update the style cache marker so browsers load the adjustment immediately

## Validation

- visually checked the desktop credentials section
- measured all six institution cells; each begins at the same horizontal position
- passed file consistency and whitespace checks
