### PR TITLE
Add Apple-style section progress rail

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -614,6 +614,101 @@ button { font: inherit; }
 .contact-links a { min-height: 44px; display: inline-flex; align-items: center; color: var(--muted); font-family: var(--font-mono); font-size: 12px; border-bottom: 1px solid transparent; }
 .contact-links a:hover { color: var(--accent); border-color: var(--accent); }
 
+/* Section progress rail */
+.scroll-rail {
+    position: fixed;
+    top: 50%;
+    right: max(28px, env(safe-area-inset-right));
+    z-index: 85;
+    width: 1px;
+    height: min(46vh, 420px);
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transform: translateY(-50%);
+    transition: opacity var(--transition), visibility var(--transition);
+}
+
+.scroll-rail.visible {
+    opacity: 1;
+    visibility: visible;
+}
+
+.rail-track {
+    position: relative;
+    width: 1px;
+    height: 100%;
+    background: var(--line);
+}
+
+.rail-fill {
+    position: absolute;
+    inset: 0;
+    background: var(--accent);
+    transform: scaleY(0);
+    transform-origin: top center;
+    transition: transform 80ms linear;
+    will-change: transform;
+}
+
+.rail-tick {
+    position: absolute;
+    top: var(--tick-position, 0%);
+    right: -5px;
+    width: 140px;
+    min-height: 28px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 7px;
+    color: var(--faint);
+    font-family: var(--font-mono);
+    font-size: 9px;
+    letter-spacing: 0.04em;
+    text-transform: lowercase;
+    pointer-events: auto;
+    transform: translateY(-50%);
+    transition: color var(--transition);
+}
+
+.rail-tick::after {
+    content: '';
+    flex: 0 0 11px;
+    height: 1px;
+    background: var(--line);
+    transition: flex-basis var(--transition), background-color var(--transition);
+}
+
+.rail-tick-number,
+.rail-tick-name {
+    opacity: 0;
+    transform: translateX(4px);
+    transition: opacity var(--transition), transform var(--transition);
+}
+
+.rail-tick:hover,
+.rail-tick:focus-visible,
+.rail-tick.active {
+    color: var(--accent);
+}
+
+.rail-tick:hover::after,
+.rail-tick:focus-visible::after,
+.rail-tick.active::after {
+    flex-basis: 15px;
+    background: var(--accent);
+}
+
+.rail-tick:hover .rail-tick-number,
+.rail-tick:hover .rail-tick-name,
+.rail-tick:focus-visible .rail-tick-number,
+.rail-tick:focus-visible .rail-tick-name,
+.rail-tick.active .rail-tick-number,
+.rail-tick.active .rail-tick-name {
+    opacity: 1;
+    transform: translateX(0);
+}
+
 /* Floating return control */
 .back-to-top {
     position: fixed;
@@ -654,6 +749,7 @@ button { font: inherit; }
 
 /* Responsive */
 @media (max-width: 900px) {
+    .scroll-rail { display: none; }
     .hero-grid { grid-template-columns: minmax(0, 1fr) 260px; }
     .hero-portrait figcaption { font-size: 9px; letter-spacing: 0.02em; }
     .section-grid,

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-    <link href="css/styles.css?v=20260717-13" rel="stylesheet">
+    <link href="css/styles.css?v=20260717-14" rel="stylesheet">
 
     <script type="application/ld+json">
     {
@@ -416,7 +416,7 @@
             </div>
         </section>
 
-        <section class="section builder-note" aria-labelledby="builder-title">
+        <section class="section builder-note" id="build-mode" aria-labelledby="builder-title">
             <div class="wrap builder-note-inner">
                 <span class="section-num">05</span>
                 <div>
@@ -476,6 +476,18 @@
         </section>
     </main>
 
+    <nav class="scroll-rail" id="scrollRail" aria-label="Section progress">
+        <div class="rail-track">
+            <span class="rail-fill" aria-hidden="true"></span>
+            <a class="rail-tick" href="#work"><span class="rail-tick-number">01</span><span class="rail-tick-name">work</span></a>
+            <a class="rail-tick" href="#about"><span class="rail-tick-number">02</span><span class="rail-tick-name">expertise</span></a>
+            <a class="rail-tick" href="#experience"><span class="rail-tick-number">03</span><span class="rail-tick-name">experience</span></a>
+            <a class="rail-tick" href="#credentials"><span class="rail-tick-number">04</span><span class="rail-tick-name">credentials</span></a>
+            <a class="rail-tick" href="#build-mode"><span class="rail-tick-number">05</span><span class="rail-tick-name">build mode</span></a>
+            <a class="rail-tick" href="#contact"><span class="rail-tick-number">06</span><span class="rail-tick-name">contact</span></a>
+        </div>
+    </nav>
+
     <button class="back-to-top" id="backToTop" type="button" aria-label="Back to top" aria-hidden="true" tabindex="-1">
         <span class="back-to-top-arrow" aria-hidden="true">↑</span>
         <span class="back-to-top-label" aria-hidden="true">top</span>
@@ -488,7 +500,7 @@
         </div>
     </footer>
 
-    <script src="scripts/scripts.js?v=20260717-4"></script>
+    <script src="scripts/scripts.js?v=20260717-5"></script>
 </body>
 
 </html>

--- a/jarvis/index.html
+++ b/jarvis/index.html
@@ -45,7 +45,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-    <link href="../css/styles.css?v=20260717-13" rel="stylesheet">
+    <link href="../css/styles.css?v=20260717-14" rel="stylesheet">
     <link href="jarvis.css?v=20260716-2" rel="stylesheet">
 </head>
 
@@ -221,6 +221,16 @@
         </section>
     </main>
 
+    <nav class="scroll-rail" id="scrollRail" aria-label="Section progress">
+        <div class="rail-track">
+            <span class="rail-fill" aria-hidden="true"></span>
+            <a class="rail-tick" href="#overview"><span class="rail-tick-number">01</span><span class="rail-tick-name">overview</span></a>
+            <a class="rail-tick" href="#system"><span class="rail-tick-number">02</span><span class="rail-tick-name">system</span></a>
+            <a class="rail-tick" href="#decisions"><span class="rail-tick-number">03</span><span class="rail-tick-name">decisions</span></a>
+            <a class="rail-tick" href="#outcomes"><span class="rail-tick-number">04</span><span class="rail-tick-name">outcomes</span></a>
+        </div>
+    </nav>
+
     <button class="back-to-top" id="backToTop" type="button" aria-label="Back to top" aria-hidden="true" tabindex="-1">
         <span class="back-to-top-arrow" aria-hidden="true">↑</span>
         <span class="back-to-top-label" aria-hidden="true">top</span>
@@ -230,7 +240,7 @@
         <div class="wrap footer-inner"><span>© 2026 Stephen Robinson</span><a href="#top">Back to top ↑</a></div>
     </footer>
 
-    <script src="../scripts/scripts.js?v=20260717-4"></script>
+    <script src="../scripts/scripts.js?v=20260717-5"></script>
 </body>
 
 </html>

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -173,3 +173,85 @@
     window.addEventListener('scroll', update, { passive: true });
     update();
 })();
+
+// Proportional section progress rail.
+(function () {
+    var rail = document.getElementById('scrollRail');
+    if (!rail) return;
+
+    var fill = rail.querySelector('.rail-fill');
+    var ticks = Array.prototype.slice.call(rail.querySelectorAll('.rail-tick[href^="#"]'));
+    var activeOffset = 130;
+    var maxScroll = 1;
+    var scrollFrame = null;
+    var resizeFrame = null;
+
+    var targets = ticks.map(function (tick) {
+        var id = tick.getAttribute('href').slice(1);
+        var element = document.getElementById(id);
+        return element ? { tick: tick, element: element } : null;
+    }).filter(Boolean);
+
+    if (!fill || !targets.length) return;
+
+    var update = function () {
+        var scrollY = window.scrollY;
+        var progress = Math.min(1, Math.max(0, scrollY / maxScroll));
+        var position = scrollY + activeOffset;
+        var current = null;
+
+        fill.style.transform = 'scaleY(' + progress + ')';
+        rail.classList.toggle('visible', scrollY > 240);
+
+        targets.forEach(function (target) {
+            if (target.element.offsetTop <= position) current = target;
+        });
+
+        ticks.forEach(function (tick) {
+            tick.classList.remove('active');
+            tick.removeAttribute('aria-current');
+        });
+
+        if (current) {
+            current.tick.classList.add('active');
+            current.tick.setAttribute('aria-current', 'location');
+        }
+    };
+
+    var measure = function () {
+        var documentHeight = Math.max(
+            document.documentElement.scrollHeight,
+            document.body.scrollHeight
+        );
+        maxScroll = Math.max(1, documentHeight - window.innerHeight);
+
+        targets.forEach(function (target) {
+            var activationPoint = Math.max(0, target.element.offsetTop - activeOffset);
+            var tickPosition = Math.min(100, Math.max(0, activationPoint / maxScroll * 100));
+            target.tick.style.setProperty('--tick-position', tickPosition + '%');
+        });
+
+        update();
+    };
+
+    var requestUpdate = function () {
+        if (scrollFrame !== null) return;
+        scrollFrame = requestAnimationFrame(function () {
+            scrollFrame = null;
+            update();
+        });
+    };
+
+    var requestMeasure = function () {
+        if (resizeFrame !== null) return;
+        resizeFrame = requestAnimationFrame(function () {
+            resizeFrame = null;
+            measure();
+        });
+    };
+
+    window.addEventListener('scroll', requestUpdate, { passive: true });
+    window.addEventListener('resize', requestMeasure);
+    window.addEventListener('load', measure, { once: true });
+    measure();
+})();


### PR DESCRIPTION
## Summary

- add a desktop-only, right-edge section progress rail to the portfolio and JARVIS case study
- position ticks from actual section offsets and update the amber fill with an rAF-throttled transform
- expose active and hovered section labels while preserving the existing mobile breakpoint and reduced-motion behavior

## Validation

- checked JavaScript syntax and whitespace
- verified desktop section synchronization, real rail-link navigation, dark-theme tokens, back-to-top clearance, and refresh-to-top behavior
- verified the rail is hidden at the existing `max-width: 900px` breakpoint and that reduced-motion globally disables transitions
