### PR TITLE
Remove mobile top button shadow

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -863,7 +863,7 @@ button { font: inherit; }
     .project-visual { min-height: 270px; }
     .brand-preview { min-height: 240px; }
     .lab-list li { grid-template-columns: 1fr; gap: 2px; padding: 10px 0; }
-    .back-to-top { right: max(14px, env(safe-area-inset-right)); bottom: calc(14px + env(safe-area-inset-bottom)); width: 52px; height: 52px; }
+    .back-to-top { right: max(14px, env(safe-area-inset-right)); bottom: calc(14px + env(safe-area-inset-bottom)); width: 52px; height: 52px; box-shadow: none; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/css/styles.css
+++ b/css/styles.css
@@ -863,7 +863,14 @@ button { font: inherit; }
     .project-visual { min-height: 270px; }
     .brand-preview { min-height: 240px; }
     .lab-list li { grid-template-columns: 1fr; gap: 2px; padding: 10px 0; }
-    .back-to-top { right: max(14px, env(safe-area-inset-right)); bottom: calc(14px + env(safe-area-inset-bottom)); width: 52px; height: 52px; box-shadow: none; }
+    .back-to-top {
+        right: max(14px, env(safe-area-inset-right));
+        bottom: calc(14px + env(safe-area-inset-bottom));
+        width: 52px;
+        height: 52px;
+        box-shadow: none !important;
+        filter: none;
+    }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/index.html
+++ b/index.html
@@ -52,7 +52,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-    <link href="css/styles.css?v=20260717-14" rel="stylesheet">
+    <link href="css/styles.css?v=20260717-15" rel="stylesheet">
 
     <script type="application/ld+json">
     {

--- a/jarvis/index.html
+++ b/jarvis/index.html
@@ -45,7 +45,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-    <link href="../css/styles.css?v=20260717-14" rel="stylesheet">
+    <link href="../css/styles.css?v=20260717-15" rel="stylesheet">
     <link href="jarvis.css?v=20260716-2" rel="stylesheet">
 </head>
 


### PR DESCRIPTION
## Summary

Removes the unwanted drop shadow beneath the mobile floating Top button and updates the stylesheet cache version on both site pages.

## Why

The inherited floating-button shadow remained visible on mobile. Existing browser caches could also continue serving the earlier stylesheet after the first fix.

## Impact

The mobile control retains its size, placement, visibility behavior, and theme treatment without the shadow beneath it. Desktop styling is unchanged.

## Validation

- verified the mobile override clears the box shadow and filter
- checked the scoped diff for whitespace errors
