### PR TITLE
Refine hero typography emphasis

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -135,7 +135,7 @@ button { font: inherit; }
     align-items: center;
     font-family: var(--font-mono);
     font-size: 14px;
-    font-weight: 500;
+    font-weight: 700;
     letter-spacing: 0.02em;
     white-space: nowrap;
 }
@@ -244,7 +244,7 @@ button { font: inherit; }
     max-width: 11ch;
     margin-bottom: 22px;
     font-family: var(--font-display);
-    font-size: clamp(50px, 7.4vw, 86px);
+    font-size: clamp(46px, 6.7vw, 78px);
     font-weight: 600;
     line-height: 0.98;
     letter-spacing: -0.045em;
@@ -258,6 +258,8 @@ button { font: inherit; }
     font-size: clamp(17px, 1.8vw, 20px);
     line-height: 1.52;
 }
+
+.lead strong { font-weight: 700; }
 
 .now {
     max-width: 58ch;
@@ -796,7 +798,7 @@ button { font: inherit; }
     .hero-portrait-frame::before { transform: translate(10px, 10px); }
     .hero-portrait figcaption { display: block; margin-top: 18px; text-align: center; font-size: 9px; letter-spacing: 0.025em; }
     .kicker { margin-bottom: 16px; font-size: 10px; }
-    .hero-h1 { margin-bottom: 18px; font-size: clamp(43px, 13vw, 58px); }
+    .hero-h1 { margin-bottom: 18px; font-size: clamp(40px, 12vw, 54px); }
     .lead { font-size: 16px; }
     .now { font-size: 13px; }
     .hero-actions { gap: 8px; }

--- a/index.html
+++ b/index.html
@@ -51,8 +51,8 @@
     <link rel="manifest" href="site.webmanifest">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-    <link href="css/styles.css?v=20260717-15" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
+    <link href="css/styles.css?v=20260717-16" rel="stylesheet">
 
     <script type="application/ld+json">
     {
@@ -124,7 +124,7 @@
                 <div class="hero-text">
                     <p class="kicker"><span class="kicker-mark"></span>Technical program leader · Applied AI builder</p>
                     <h1 class="hero-h1" id="hero-title">Complex programs.<br><span>Clear outcomes.</span></h1>
-                    <p class="lead">I'm Stephen Robinson. I lead high-stakes enterprise technology programs and build practical AI systems that turn complexity into measurable business value.</p>
+                    <p class="lead">I'm <strong>Stephen Robinson</strong>. I lead high-stakes enterprise technology programs and build practical AI systems that turn complexity into measurable business value.</p>
                     <p class="now"><span class="now-tag">Now</span> Leading a $1.26M infrastructure modernization program at NBCUniversal, projected to save $4M+ this year.</p>
                     <div class="hero-actions" aria-label="Featured actions">
                         <a href="#work" class="button button-primary">View case studies <span aria-hidden="true">↓</span></a>

--- a/jarvis/index.html
+++ b/jarvis/index.html
@@ -44,8 +44,8 @@
     <link rel="apple-touch-icon" href="../images/apple-touch-icon.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=Inter:wght@400;500;600&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
-    <link href="../css/styles.css?v=20260717-15" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&amp;family=Inter:wght@400;500;600;700&amp;family=JetBrains+Mono:wght@400;500&amp;display=swap" rel="stylesheet">
+    <link href="../css/styles.css?v=20260717-16" rel="stylesheet">
     <link href="jarvis.css?v=20260716-2" rel="stylesheet">
 </head>
 


### PR DESCRIPTION
## Summary

- reduce the portfolio hero headline by one responsive type step
- emphasize Stephen Robinson in the primary wordmark and opening introduction
- load the bold Inter weight and refresh the shared stylesheet cache version

## Why

The hero headline was visually oversized, while the personal identity in the navigation and introduction needed stronger hierarchy.

## Impact

The landing page reads with a more balanced hero scale and clearer personal attribution across themes. The shared navigation wordmark is bold on the JARVIS page as well.

## Validation

- checked the scoped diff for whitespace errors
- confirmed the workspace and publishing checkout have identical changed files
